### PR TITLE
Small fixes for Docker installation instructions

### DIFF
--- a/docs/installing/docker.md
+++ b/docs/installing/docker.md
@@ -9,8 +9,9 @@ This guide helps you set up hoop with Docker.
 
 ## All In One
 
-Start all components and test hoop locally (it requires docker).
-Follow the in-screen instructions to walk you through the solution
+Start all components and test hoop locally (this requires Docker).
+
+Follow the on-screen instructions to walk you through the solution.
 
 ```shell
 hoop start
@@ -24,24 +25,23 @@ The command above is analougous to:
 docker run -p 8009:8009 -p 8010:8010 -e PROFILE=dev --rm -it hoophq/hoop
 ```
 
-- The port `8009` hosts the webapp, check it out http://127.0.0.1:8009
-- The port `8010` exposes the gprc gateway which let you interact with `hoop exec|connect`
-
-> The `PROFILE=dev` will fallback to start all required components
+- The port `8009` hosts the webapp, check it out at http://127.0.0.1:8009
+- The port `8010` exposes the gprc gateway which lets you interact with `hoop exec|connect`
+- The `PROFILE=dev` will fallback to start all required components.
 
 ## Gateway
 
-To run a standalone gateway on docker in production, check the [container-platforms generic guide](../container-platforms/generic) to see all the requirements.
+To run a standalone gateway on Docker in production, check the [container-platforms generic guide](../container-platforms/generic) to see all the requirements.
 
 ## Agent
 
-The image `hoophq/hoop` has the hoop command line, which can started each component individually
+The image `hoophq/hoop` has the hoop command line, which can start each component individually.
 
 ```shell
 docker run --rm -ti hoophq/hoop hoop start agent
 ```
 
-To deploy a production agent, we recommend the image `hoophq/hoopdev`. It doesn't require passing any arguments
+To deploy a production agent, we recommend the image `hoophq/hoopdev`. It doesn't require passing any arguments.
 
 ```shell
 docker run --rm -ti hoophq/hoopdev


### PR DESCRIPTION
* Adds a few small grammatical clean-ups for the Docker instructions.

At **ritza.co** we love helping technical, developer-first companies create world-class documentation and other technical resources. If you need help with technical writing, developer advocacy, or anything else, feel free to let us know. 

<img width="1177" alt="screenshot 2023-08-24 at 11 58 15@2x" src="https://github.com/hoophq/docs/assets/2641205/7760947d-0335-432e-8874-8b516810e227">
